### PR TITLE
move to github hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: Consensus Workbench CI
 on: push
 jobs:
   tests:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --verbose
   clippy:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -18,7 +18,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: cargo +nightly clippy
   format:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Now the repo is publich we should't use self hosted runners anymore