### PR TITLE
[Blockchain] Fix miner task

### DIFF
--- a/src/blockchain/ledger.rs
+++ b/src/blockchain/ledger.rs
@@ -7,9 +7,10 @@ use itertools::Itertools;
 
 use lib::command::Command;
 use log::{debug, warn};
-use rand::Rng;
+use rand::{Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::sync::mpsc::Receiver;
 
 // Difficulty is expressed as the maximum u32 unsigned integer shifted a number of
 // bits to the right. This way, a difficulty of u32::MAX >> n means "the hash has
@@ -18,7 +19,7 @@ const DIFFICULTY_TARGET: u32 = if cfg!(test) {
     // Lower the difficulty for testing so it doesn't take very long
     u32::MAX >> 16
 } else {
-    u32::MAX >> 18
+    u32::MAX >> 20
 };
 
 pub type TransactionId = String;
@@ -198,9 +199,9 @@ impl Ledger {
         miner_id: &str,
         previous_block: Block,
         transactions: Vec<Transaction>,
-    ) -> Block {
+    ) -> Option<Block> {
         debug!("mining block...");
-        let initial_nonce = rand::thread_rng().gen_range(0, 100000000);
+        let initial_nonce = rand::thread_rng().next_u64();
         let mut candidate = Block {
             height: previous_block.height + 1,
             miner_id: miner_id.to_string(),
@@ -213,6 +214,7 @@ impl Ledger {
         loop {
             if candidate.nonce % Self::MINER_LOG_EVERY == 0 {
                 debug!("nonce: {}", candidate.nonce);
+                return None;
             }
             candidate.hash = candidate.calculate_hash();
             // I'm unwrapping because the only posible error is `candidate.hash` not
@@ -223,7 +225,7 @@ impl Ledger {
                     candidate.nonce, candidate.hash
                 );
 
-                return candidate;
+                return Some(candidate);
             }
             candidate.nonce += 1;
         }

--- a/src/blockchain/ledger.rs
+++ b/src/blockchain/ledger.rs
@@ -223,6 +223,8 @@ impl Ledger {
                 // and the task keeps mining until it finds a (now invalid and thus useless) PoW.
                 // Therefore, every once in a while this mining function will yield to make sure
                 // it aborts if it has to.
+                // In a production-like environment, we would setup a worker pool outside of tokio to handle this
+                // cpu-bound job, but we prefer to keep it simple for this implementation.
                 tokio::task::yield_now().await;
             }
             candidate.hash = candidate.calculate_hash();

--- a/src/blockchain/node.rs
+++ b/src/blockchain/node.rs
@@ -3,7 +3,6 @@
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use core::fmt;
-use lib::command::Command;
 use lib::network::SimpleSender;
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
@@ -12,7 +11,6 @@ use std::{collections::HashMap, net::SocketAddr};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-pub type Transaction = (TransactionId, Command);
 
 use lib::command::Command as ClientCommand;
 
@@ -64,9 +62,6 @@ pub struct Node {
 
     /// A copy of the sender end of the mining channel, held to pass to each new miner task.
     miner_sender: Sender<Block>,
-
-    /// The channel handler the node uses to send new work to the miner task
-    miner_work_sender: Sender<(Block, Vec<Transaction>)>,
 }
 
 use ClientCommand::*;
@@ -83,28 +78,6 @@ impl Node {
         }
 
         let (miner_sender, miner_receiver) = channel(2);
-        let (miner_work_sender, mut miner_work_receiver) = channel(2);
-        let miner_sender_clone = miner_sender.clone();
-
-        let miner_task = tokio::task::spawn_blocking(move || loop {
-            match miner_work_receiver.try_recv() {
-                Ok((previous_block, transactions)) => {
-                    debug!(
-                        "Received new mining message {:?} {:?}",
-                        previous_block, transactions
-                    );
-                    match Ledger::mine_block(&address.to_string(), previous_block, transactions) {
-                        Some(new_block) => {
-                            if let Err(err) = miner_sender.blocking_send(new_block) {
-                                error!("error sending mined block {}", err);
-                            }
-                        }
-                        None => {}
-                    }
-                }
-                Err(_) => {}
-            }
-        });
 
         Self {
             address,
@@ -112,10 +85,9 @@ impl Node {
             sender: SimpleSender::new(),
             mempool: HashMap::new(),
             ledger: Ledger::new(),
-            miner_task: miner_task,
-            miner_sender: miner_sender_clone,
-            miner_receiver: miner_receiver,
-            miner_work_sender: miner_work_sender,
+            miner_task: tokio::spawn(async {}), // noop default
+            miner_sender,
+            miner_receiver,
         }
     }
 
@@ -125,7 +97,7 @@ impl Node {
         &mut self,
         mut network_receiver: Receiver<(Message, oneshot::Sender<Result<Option<String>>>)>,
     ) -> JoinHandle<()> {
-        self.restart_miner().await;
+        self.restart_miner();
 
         // ask the seeds for their current state to catch up with the ledger and learn about peers
         let startup_message = GetState {
@@ -246,7 +218,7 @@ impl Node {
 
         // since the ledger and the mempool changed, the current miner task extending the old one is invalid
         // so we abort it and restart mining based on the latest ledger
-        self.restart_miner().await;
+        self.restart_miner();
 
         let message = State {
             from: self.address,
@@ -257,15 +229,18 @@ impl Node {
     }
 
     /// Abort the currently running miner task and start a new one based on the latest ledger and mempool.
-    async fn restart_miner(&mut self) {
-        debug!("Restarting miner...");
+    fn restart_miner(&mut self) {
         let previous_block = self.ledger.blocks.last().unwrap().clone();
         let transactions = self.mempool.clone().into_iter().collect();
-
-        self.miner_work_sender
-            .send((previous_block, transactions))
-            .await
-            .unwrap();
+        let sender = self.miner_sender.clone();
+        let miner_id = self.address.to_string();
+        self.miner_task.abort();
+        self.miner_task = tokio::spawn(async move {
+            let new_block = Ledger::mine_block(&miner_id, previous_block, transactions);
+            if let Err(err) = sender.send(new_block).await {
+                error!("error sending mined block {}", err);
+            }
+        });
     }
 
     /// Send the given message to all known peers. Doesn't wait for acknowledge.
@@ -367,7 +342,7 @@ mod tests {
         assert!(node.mempool.contains_key("tx2"));
 
         // don't include a transaction in the mempool if it's already in the ledger
-        node.restart_miner().await;
+        node.restart_miner();
         let block = node.miner_receiver.recv().await.unwrap();
         let new_ledger = node.ledger.extend(block).unwrap();
         node.update_ledger(new_ledger).await;
@@ -404,7 +379,7 @@ mod tests {
         assert_eq!(1, node1.ledger.blocks.len());
 
         // mine a block in one of the nodes
-        node1.restart_miner().await;
+        node1.restart_miner();
         let block = node1.miner_receiver.recv().await.unwrap();
         let new_ledger = node1.ledger.extend(block).unwrap();
         node1.update_ledger(new_ledger.clone()).await;

--- a/src/blockchain/node.rs
+++ b/src/blockchain/node.rs
@@ -230,13 +230,14 @@ impl Node {
 
     /// Abort the currently running miner task and start a new one based on the latest ledger and mempool.
     fn restart_miner(&mut self) {
+        debug!("Restarting miner...");
         let previous_block = self.ledger.blocks.last().unwrap().clone();
         let transactions = self.mempool.clone().into_iter().collect();
         let sender = self.miner_sender.clone();
         let miner_id = self.address.to_string();
         self.miner_task.abort();
         self.miner_task = tokio::spawn(async move {
-            let new_block = Ledger::mine_block(&miner_id, previous_block, transactions);
+            let new_block = Ledger::mine_block(&miner_id, previous_block, transactions).await;
             if let Err(err) = sender.send(new_block).await {
                 error!("error sending mined block {}", err);
             }


### PR DESCRIPTION
Currently, the way the blockchain node does the mining is through a tokio task called `miner_task` that it keeps as a member variable. The basic flow for mining is the following:

- The node starts up and spawns a `miner_task`, which continuously tries to find a proof of work for the current proposed block by incrementing a nonce and hashing.
    - If the task finds a proof of work, it sends it to the node through a channel and exits. At this point the node adds the newly found block to its ledger, then spawns a new `miner_task` and it all starts again.
    - If the node gets a message from another node with a valid proof of work on a longer chain, the node aborts the current `miner_task` and spawns a new one in its place to mine a block on top of the newly received one:
    ```
    self.miner_task.abort();
    self.miner_task = tokio::spawn(async move {
        let new_block = Ledger::mine_block(&miner_id, previous_block, transactions);
         if let Err(err) = sender.send(new_block).await {
            error!("error sending mined block {}", err);
        }
    });
    ```

The problem with this is that the abort doesn't work, the old `miner_task` does not exit until it finds the proof of work, ignoring the abort signal. This is because the task is a cpu-bound one that never yields, so the executor never gets to send the signal.

~~This PR attemps to fix that by changing the flow. The idea is to have only one `miner_task` spawned at the beginning along with a channel, and when it needs to be restarted we use the channel to send it the new data (previous block and transactions) to do the mining.~~

The solution we ended up going for is to simply have the mining function yield every once in a while, so the executor can take over and abort it if necessary. This is not ideal, as the mining task (being a cpu-bound one) should probably just run on a separate thread independent of the tokio runtime (maybe through a `spawn_blocking` call), but it makes the code way simpler to follow/understand, which we care more about right now.