### PR TITLE
Separate client and network receives in blockchain node

### DIFF
--- a/src/blockchain/main.rs
+++ b/src/blockchain/main.rs
@@ -41,29 +41,32 @@ async fn main() {
 
     simple_logger::SimpleLogger::new().env().init().unwrap();
 
-    let address = SocketAddr::new(cli.address, cli.port);
+    let network_address = SocketAddr::new(cli.address, cli.port);
+    // FIXME lazily assuming +1000 for client port. move to CLI if anyone cares about it
+    let client_address = SocketAddr::new(cli.address, cli.port + 1000);
 
-    let (_, network_handle, _) = spawn_node_tasks(address, cli.seed).await;
+    let (_, network_handle, _) = spawn_node_tasks(network_address, client_address, cli.seed).await;
 
     network_handle.await.unwrap();
 }
 
 /// Spawn the network receiver and a blockchain node with a channel to pass messages from one to the other.
 async fn spawn_node_tasks(
-    address: SocketAddr,
+    network_address: SocketAddr,
+    client_address: SocketAddr,
     seed: Option<SocketAddr>,
 ) -> (JoinHandle<()>, JoinHandle<()>, JoinHandle<()>) {
     let (network_sender, network_receiver) = channel(CHANNEL_CAPACITY);
     let (client_sender, client_receiver) = channel(CHANNEL_CAPACITY);
 
     let node_handle = tokio::spawn(async move {
-        let mut node = Node::new(address, seed);
+        let mut node = Node::new(network_address, seed);
         node.run(network_receiver, client_receiver).await;
     });
 
     let network_handle = tokio::spawn(async move {
         let receiver = NetworkReceiver::new(
-            address,
+            network_address,
             NetworkReceiverHandler {
                 sender: network_sender,
             },
@@ -73,7 +76,7 @@ async fn spawn_node_tasks(
 
     let client_handle = tokio::spawn(async move {
         let receiver = NetworkReceiver::new(
-            address,
+            client_address,
             ClientReceiverHandler {
                 sender: client_sender,
             },
@@ -139,14 +142,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn single_node() {
-        let address: SocketAddr = "127.0.0.1:6379".parse().unwrap();
-        spawn_node_tasks(address, None).await;
+        let network_address: SocketAddr = "127.0.0.1:6379".parse().unwrap();
+        let client_address: SocketAddr = "127.0.0.1:7379".parse().unwrap();
+        spawn_node_tasks(network_address, client_address, None).await;
 
         // get k1 -> null
         let reply = ClientCommand::Get {
             key: "k1".to_string(),
         }
-        .send_to(address)
+        .send_to(client_address)
         .await
         .unwrap();
         assert!(reply.is_none());
@@ -156,145 +160,159 @@ mod tests {
             key: "k1".to_string(),
             value: "v1".to_string(),
         }
-        .send_to(address)
+        .send_to(client_address)
         .await
         .unwrap();
         assert!(reply.is_some());
         assert_eq!("v1".to_string(), reply.unwrap());
 
         // eventually value gets into a block and get k1 -> v1
-        assert_eventually_equals(address, "k1", "v1").await;
+        assert_eventually_equals(client_address, "k1", "v1").await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn multiple_nodes() {
-        let address1: SocketAddr = "127.0.0.1:6279".parse().unwrap();
-        let address2: SocketAddr = "127.0.0.1:6289".parse().unwrap();
-        let address3: SocketAddr = "127.0.0.1:6299".parse().unwrap();
-        spawn_node_tasks(address1, None).await;
-        spawn_node_tasks(address2, Some(address1)).await;
-        spawn_node_tasks(address3, Some(address1)).await;
+        let network_address1: SocketAddr = "127.0.0.1:6279".parse().unwrap();
+        let network_address2: SocketAddr = "127.0.0.1:6289".parse().unwrap();
+        let network_address3: SocketAddr = "127.0.0.1:6299".parse().unwrap();
+
+        let client_address1: SocketAddr = "127.0.0.1:7279".parse().unwrap();
+        let client_address2: SocketAddr = "127.0.0.1:7289".parse().unwrap();
+        let client_address3: SocketAddr = "127.0.0.1:7299".parse().unwrap();
+        spawn_node_tasks(network_address1, client_address1, None).await;
+        spawn_node_tasks(network_address2, client_address2, Some(network_address1)).await;
+        spawn_node_tasks(network_address3, client_address3, Some(network_address1)).await;
 
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v1".to_string(),
         }
-        .send_to(address1)
+        .send_to(client_address1)
         .await
         .unwrap();
 
         // eventually value gets into a block and get k1 -> v1 (in all nodes)
-        assert_eventually_equals(address1, "k1", "v1").await;
-        assert_eventually_equals(address2, "k1", "v1").await;
-        assert_eventually_equals(address3, "k1", "v1").await;
+        assert_eventually_equals(client_address1, "k1", "v1").await;
+        assert_eventually_equals(client_address2, "k1", "v1").await;
+        assert_eventually_equals(client_address3, "k1", "v1").await;
 
         // set k=v2 (another node) -> eventually v2 in 1
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v2".to_string(),
         }
-        .send_to(address2)
+        .send_to(client_address2)
         .await
         .unwrap();
-        assert_eventually_equals(address1, "k1", "v2").await;
-        assert_eventually_equals(address2, "k1", "v2").await;
-        assert_eventually_equals(address3, "k1", "v2").await;
+        assert_eventually_equals(client_address1, "k1", "v2").await;
+        assert_eventually_equals(client_address2, "k1", "v2").await;
+        assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn new_node_catch_up() {
         // start two nodes
-        let address1: SocketAddr = "127.0.0.1:6179".parse().unwrap();
-        let address2: SocketAddr = "127.0.0.1:6189".parse().unwrap();
-        spawn_node_tasks(address1, None).await;
-        spawn_node_tasks(address2, Some(address1)).await;
+        let network_address1: SocketAddr = "127.0.0.1:6179".parse().unwrap();
+        let network_address2: SocketAddr = "127.0.0.1:6189".parse().unwrap();
+
+        let client_address1: SocketAddr = "127.0.0.1:7179".parse().unwrap();
+        let client_address2: SocketAddr = "127.0.0.1:7189".parse().unwrap();
+        spawn_node_tasks(network_address1, client_address1, None).await;
+        spawn_node_tasks(network_address2, client_address2, Some(network_address1)).await;
 
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v1".to_string(),
         }
-        .send_to(address1)
+        .send_to(client_address1)
         .await
         .unwrap();
 
         // eventually value gets into a block and get k1 -> v1 (in all nodes)
-        assert_eventually_equals(address1, "k1", "v1").await;
-        assert_eventually_equals(address2, "k1", "v1").await;
+        assert_eventually_equals(client_address1, "k1", "v1").await;
+        assert_eventually_equals(client_address2, "k1", "v1").await;
 
         // set k=v2 (another node) -> eventually v2 in 1
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v2".to_string(),
         }
-        .send_to(address2)
+        .send_to(client_address2)
         .await
         .unwrap();
-        assert_eventually_equals(address1, "k1", "v2").await;
-        assert_eventually_equals(address2, "k1", "v2").await;
+        assert_eventually_equals(client_address1, "k1", "v2").await;
+        assert_eventually_equals(client_address2, "k1", "v2").await;
 
         // start another node, which should eventually catch up with the longest chain from its peers
-        let address3: SocketAddr = "127.0.0.1:6199".parse().unwrap();
-        spawn_node_tasks(address3, Some(address1)).await;
-        assert_eventually_equals(address3, "k1", "v2").await;
+        let network_address3: SocketAddr = "127.0.0.1:6199".parse().unwrap();
+        let client_address3: SocketAddr = "127.0.0.1:7199".parse().unwrap();
+        spawn_node_tasks(network_address3, client_address3, Some(network_address1)).await;
+        assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn node_crash_recover() {
-        let address1: SocketAddr = "127.0.0.1:6579".parse().unwrap();
-        let address2: SocketAddr = "127.0.0.1:6589".parse().unwrap();
-        let address3: SocketAddr = "127.0.0.1:6599".parse().unwrap();
+        let network_address1: SocketAddr = "127.0.0.1:6579".parse().unwrap();
+        let network_address2: SocketAddr = "127.0.0.1:6589".parse().unwrap();
+        let network_address3: SocketAddr = "127.0.0.1:6599".parse().unwrap();
 
-        spawn_node_tasks(address1, None).await;
+        let client_address1: SocketAddr = "127.0.0.1:7579".parse().unwrap();
+        let client_address2: SocketAddr = "127.0.0.1:7589".parse().unwrap();
+        let client_address3: SocketAddr = "127.0.0.1:7599".parse().unwrap();
+
+        spawn_node_tasks(network_address1, client_address1, None).await;
         // keep the handles to abort later
-        let (network_handle, node_handle) = spawn_node_tasks(address2, Some(address1)).await;
-        spawn_node_tasks(address3, Some(address1)).await;
+        let (node_handle, network_handle, client_handle) =
+            spawn_node_tasks(network_address2, client_address2, Some(network_address1)).await;
+        spawn_node_tasks(network_address3, client_address3, Some(network_address1)).await;
 
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v1".to_string(),
         }
-        .send_to(address1)
+        .send_to(client_address1)
         .await
         .unwrap();
 
         // eventually value gets into a block and get k1 -> v1 (in all nodes)
-        assert_eventually_equals(address1, "k1", "v1").await;
-        assert_eventually_equals(address2, "k1", "v1").await;
-        assert_eventually_equals(address3, "k1", "v1").await;
+        assert_eventually_equals(client_address1, "k1", "v1").await;
+        assert_eventually_equals(client_address2, "k1", "v1").await;
+        assert_eventually_equals(client_address3, "k1", "v1").await;
 
         // abort the 2nd node
         network_handle.abort();
         node_handle.abort();
+        client_handle.abort();
 
         // send another transaction
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v2".to_string(),
         }
-        .send_to(address1)
+        .send_to(client_address1)
         .await
         .unwrap();
 
         // the nodes that are still alive eventually update the value
-        assert_eventually_equals(address1, "k1", "v2").await;
-        assert_eventually_equals(address3, "k1", "v2").await;
+        assert_eventually_equals(client_address3, "k1", "v2").await;
+        assert_eventually_equals(client_address1, "k1", "v2").await;
 
         // start the second node again
-        spawn_node_tasks(address2, Some(address1)).await;
+        spawn_node_tasks(network_address2, client_address2, Some(network_address1)).await;
 
         // send a new transaction to the fresh right away
         ClientCommand::Set {
             key: "k1".to_string(),
             value: "v3".to_string(),
         }
-        .send_to(address2)
+        .send_to(client_address2)
         .await
         .unwrap();
 
         // the agreed ledger should eventually include the last transaction
-        assert_eventually_equals(address1, "k1", "v3").await;
-        assert_eventually_equals(address2, "k1", "v3").await;
-        assert_eventually_equals(address3, "k1", "v3").await;
+        assert_eventually_equals(client_address1, "k1", "v3").await;
+        assert_eventually_equals(client_address2, "k1", "v3").await;
+        assert_eventually_equals(client_address3, "k1", "v3").await;
     }
 
     /// Send Get commands to the given address with delayed retries to give it time for a transaction

--- a/src/blockchain/main.rs
+++ b/src/blockchain/main.rs
@@ -114,7 +114,7 @@ mod tests {
         assert_eventually_equals(client_address, "k1", "v1").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
     async fn multiple_nodes() {
         let network_address1: SocketAddr = "127.0.0.1:6279".parse().unwrap();
         let network_address2: SocketAddr = "127.0.0.1:6289".parse().unwrap();
@@ -153,7 +153,7 @@ mod tests {
         assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
     async fn new_node_catch_up() {
         // start two nodes
         let network_address1: SocketAddr = "127.0.0.1:6179".parse().unwrap();
@@ -194,7 +194,7 @@ mod tests {
         assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
     async fn node_crash_recover() {
         let network_address1: SocketAddr = "127.0.0.1:6579".parse().unwrap();
         let network_address2: SocketAddr = "127.0.0.1:6589".parse().unwrap();

--- a/src/blockchain/main.rs
+++ b/src/blockchain/main.rs
@@ -114,7 +114,7 @@ mod tests {
         assert_eventually_equals(client_address, "k1", "v1").await;
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn multiple_nodes() {
         let network_address1: SocketAddr = "127.0.0.1:6279".parse().unwrap();
         let network_address2: SocketAddr = "127.0.0.1:6289".parse().unwrap();
@@ -153,7 +153,7 @@ mod tests {
         assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn new_node_catch_up() {
         // start two nodes
         let network_address1: SocketAddr = "127.0.0.1:6179".parse().unwrap();
@@ -194,7 +194,7 @@ mod tests {
         assert_eventually_equals(client_address3, "k1", "v2").await;
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads=10)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn node_crash_recover() {
         let network_address1: SocketAddr = "127.0.0.1:6579".parse().unwrap();
         let network_address2: SocketAddr = "127.0.0.1:6589".parse().unwrap();

--- a/src/blockchain/main.rs
+++ b/src/blockchain/main.rs
@@ -72,29 +72,6 @@ async fn spawn_node_tasks(
     (node_handle, network_handle, client_handle)
 }
 
-// #[derive(Clone)]
-// struct ClientReceiverHandler<T: Serialize + Send + Clone + std::fmt::Debug> {
-//     /// Used to forward incoming TCP messages to the node
-//     sender: Sender<(ClientCommand, oneshot::Sender<T>)>,
-// }
-
-// #[async_trait]
-// impl<T: Serialize + Send + Clone + std::fmt::Debug + 'static> MessageHandler
-//     for ClientReceiverHandler<T>
-// {
-//     /// When a TCP message is received, interpret it as a node::Message and forward it to the node task.
-//     /// Send the node's response back through the TCP connection.
-//     async fn dispatch(&mut self, writer: &mut Writer, bytes: Bytes) -> Result<()> {
-//         let request = bincode::deserialize(&bytes)?;
-
-//         let (reply_sender, reply_receiver) = oneshot::channel();
-//         self.sender.send((request, reply_sender)).await?;
-//         let reply = reply_receiver.await?;
-//         let reply = bincode::serialize(&reply)?;
-//         Ok(writer.send(reply.into()).await?)
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/blockchain/node.rs
+++ b/src/blockchain/node.rs
@@ -96,7 +96,10 @@ impl Node {
     pub async fn run(
         &mut self,
         mut network_receiver: Receiver<Message>,
-        mut client_receiver: Receiver<(ClientCommand, oneshot::Sender<Result<Option<String>>>)>,
+        mut client_receiver: Receiver<(
+            ClientCommand,
+            oneshot::Sender<Result<Option<String>, String>>,
+        )>,
     ) -> JoinHandle<()> {
         self.restart_miner();
 
@@ -122,7 +125,7 @@ impl Node {
                     // for now generating the uuid here, should we let the client do it?
                     let txid = uuid::Uuid::new_v4().to_string();
                     let message = Command(txid, command);
-                    let result = self.handle_message(message.clone()).await;
+                    let result = self.handle_message(message.clone()).await.map_err(|e|e.to_string());
 
                     // in the case of clients sending a tcp request, we want to write a response directly
                     // to their connection

--- a/src/blockchain/node.rs
+++ b/src/blockchain/node.rs
@@ -1,6 +1,6 @@
 /// This module contains the definition of a node in a blockchain p2p network, where each node maintains
 /// a ledger of key/value store transactions, as well of the network messages supported between nodes.
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use bytes::Bytes;
 use core::fmt;
 use lib::network::SimpleSender;
@@ -132,7 +132,9 @@ impl Node {
                 }
                 Some(message) = network_receiver.recv() => {
                     info!("Received network message {}", message);
-                    self.handle_message(message.clone()).await;
+
+                    // FIXME network messages shouldn't fail
+                    self.handle_message(message.clone()).await.unwrap();
                 }
                 else => {
                     error!("node channels are closed");

--- a/src/blockchain/node.rs
+++ b/src/blockchain/node.rs
@@ -95,7 +95,8 @@ impl Node {
     /// task to produce blocks to extend the node's ledger.
     pub async fn run(
         &mut self,
-        mut network_receiver: Receiver<(Message, oneshot::Sender<Result<Option<String>>>)>,
+        mut network_receiver: Receiver<Message>,
+        mut client_receiver: Receiver<(ClientCommand, oneshot::Sender<Result<Option<String>>>)>,
     ) -> JoinHandle<()> {
         self.restart_miner();
 
@@ -115,15 +116,23 @@ impl Node {
                         self.update_ledger(new_ledger).await;
                     };
                 }
-                Some((message, reply_sender)) = network_receiver.recv() => {
+                Some((command, reply_sender)) = client_receiver.recv() => {
+                    info!("Received client message {}", command);
+
+                    // for now generating the uuid here, should we let the client do it?
+                    let txid = uuid::Uuid::new_v4().to_string();
+                    let message = Command(txid, command);
                     let result = self.handle_message(message.clone()).await;
 
-                    // FIXME we only send non-empty replies to clients here.
-                    // the network peer messages are done inside the handle_message function instead
-                    // this may be improved by separating the network and client listeners
+                    // in the case of clients sending a tcp request, we want to write a response directly
+                    // to their connection
                     if let Err(error) = reply_sender.send(result) {
                         error!("failed to send message {:?} response {:?}", message, error);
                     };
+                }
+                Some(message) = network_receiver.recv() => {
+                    info!("Received network message {}", message);
+                    self.handle_message(message.clone()).await;
                 }
                 else => {
                     error!("node channels are closed");
@@ -135,8 +144,6 @@ impl Node {
     /// This function is the core of the node's behavior. It process messages coming both from clients
     /// and peers, updates the local state and broadcasts updates.
     async fn handle_message(&mut self, message: Message) -> Result<Option<String>> {
-        info!("Received network message {}", message);
-
         match message {
             // When a client read request is received, just read the local ledger and send a response
             Command(_, Get { key }) => Ok(self.ledger.get(&key)),
@@ -252,25 +259,6 @@ impl Node {
             // forward the command to all replicas and wait for them to respond
             info!("Broadcasting to {:?}", peers_vec);
             self.sender.broadcast(peers_vec, data).await;
-        }
-    }
-}
-
-impl Message {
-    /// Incoming requests can be either messages sent by other nodes or client commands
-    /// (which are server implementation agnostic)
-    /// in which case they are wrapped into Message::Command to treat them uniformly by
-    /// the state machine
-    pub fn deserialize(data: Bytes) -> Result<Self> {
-        // this allows handling both client and peer messages from the same tcp listener
-        // alternatively the network code could be refactored to have different tcp connections
-        // and feeding both types of incoming messages into the same async handler task
-        if let Ok(c) = bincode::deserialize::<ClientCommand>(&data) {
-            // for now generating the uuid here, should we let the client do it?
-            let txid = uuid::Uuid::new_v4().to_string();
-            Ok(Self::Command(txid, c))
-        } else {
-            bincode::deserialize(&data).map_err(|e| anyhow!(e))
         }
     }
 }

--- a/src/blockchain/receiver.rs
+++ b/src/blockchain/receiver.rs
@@ -4,6 +4,7 @@ use futures::SinkExt;
 use log::{debug, warn};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -29,8 +30,8 @@ pub struct Receiver<Request, Response> {
 }
 
 impl<
-        Request: DeserializeOwned + std::fmt::Debug + Send + 'static,
-        Response: std::fmt::Debug + Serialize + Send + 'static,
+        Request: DeserializeOwned + Send + Debug + 'static,
+        Response: Serialize + Send + Debug + 'static,
     > Receiver<Request, Response>
 {
     /// Spawn a new network receiver handling connections from any incoming peer.

--- a/src/blockchain/receiver.rs
+++ b/src/blockchain/receiver.rs
@@ -1,5 +1,8 @@
+// FIXME temporarily adding this alternate receiver module to later be moved back to the network package
 // Copyright(C) Facebook, Inc. and its affiliates.
-use futures::stream::StreamExt as _;
+use anyhow::Result;
+use bytes::Bytes;
+use futures::stream::{SplitSink, StreamExt as _};
 use futures::SinkExt;
 use log::{debug, warn};
 use serde::de::DeserializeOwned;
@@ -14,6 +17,9 @@ use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 pub const CHANNEL_CAPACITY: usize = 1_000;
 
+/// Convenient alias for the writer end of the TCP channel.
+pub type Writer = SplitSink<Framed<TcpStream, LengthDelimitedCodec>, Bytes>;
+
 #[derive(Error, Debug)]
 pub enum NetworkError {
     #[error("Failed to accept connection: {0}")]
@@ -23,7 +29,7 @@ pub enum NetworkError {
     FailedToReceiveMessage(SocketAddr, std::io::Error),
 }
 
-// FIXME consider renaming to TcpSender, TcpReceiver, ChannelSender, ChannelReceiver, etc. to reduce ambiguity
+// TODO consider renaming to TcpSender, TcpReceiver, ChannelSender, ChannelReceiver, etc. to reduce ambiguity
 /// A TCP Receiver listens for peer connections and writes messages from all connections to a multi-producer
 /// single-consumer (mpsc) tokio channel.
 pub struct Receiver<Request, Response> {
@@ -35,7 +41,7 @@ pub struct Receiver<Request, Response> {
 }
 
 impl<
-        Request: DeserializeOwned + Send + Debug + 'static,
+        Request: DeserializeOwned + Send + Debug + Sync + 'static,
         Response: Serialize + Send + Debug + 'static,
     > Receiver<Request, Response>
 {
@@ -81,14 +87,11 @@ impl<
             while let Some(frame) = reader.next().await {
                 match frame.map_err(|e| NetworkError::FailedToReceiveMessage(peer, e)) {
                     Ok(message) => {
-                        // TODO add comments
-                        // FIXME unwraps
-                        let request = bincode::deserialize(&message.freeze()).unwrap();
-                        let (reply_sender, reply_receiver) = oneshot::channel();
-                        sender.send((request, reply_sender)).await.unwrap();
-                        let reply = reply_receiver.await.unwrap();
-                        let reply = bincode::serialize(&reply).unwrap();
-                        writer.send(reply.into()).await.unwrap();
+                        if let Err(e) =
+                            Self::dispatch(&mut writer, sender.clone(), message.freeze()).await
+                        {
+                            warn!("{}", e);
+                        }
                     }
                     Err(e) => {
                         warn!("{}", e);
@@ -98,6 +101,23 @@ impl<
             }
             debug!("Connection closed by peer {}", peer);
         });
+    }
+
+    /// Parse the incoming messages, forward then through the sender channel and wait for a response.
+    async fn dispatch(
+        writer: &mut Writer,
+        sender: mpsc::Sender<(Request, oneshot::Sender<Response>)>,
+        message: Bytes,
+    ) -> Result<()> {
+        let request = bincode::deserialize(&message)?;
+        let (reply_sender, reply_receiver) = oneshot::channel();
+        sender.send((request, reply_sender)).await?;
+
+        // TODO: review if this is safe in cases where the receiver doesn't send a reply
+        let reply = reply_receiver.await?;
+        let reply = bincode::serialize(&reply)?;
+        writer.send(reply.into()).await?;
+        Ok(())
     }
 }
 

--- a/src/blockchain/receiver.rs
+++ b/src/blockchain/receiver.rs
@@ -1,0 +1,146 @@
+// Copyright(C) Facebook, Inc. and its affiliates.
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::SplitSink;
+use futures::stream::StreamExt as _;
+use log::{debug, warn};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use std::net::SocketAddr;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+#[derive(Error, Debug)]
+pub enum NetworkError {
+    #[error("Failed to accept connection: {0}")]
+    FailedToListen(std::io::Error),
+
+    #[error("Failed to receive message from {0}: {1}")]
+    FailedToReceiveMessage(SocketAddr, std::io::Error),
+}
+
+/// Convenient alias for the writer end of the TCP channel.
+pub type Writer = SplitSink<Framed<TcpStream, LengthDelimitedCodec>, Bytes>;
+
+/// For each incoming request, we spawn a new runner responsible to receive messages and forward them
+/// through the provided deliver channel.
+pub struct Receiver<M> {
+    /// Address to listen to.
+    address: SocketAddr,
+    sender: mpsc::Sender<M>
+}
+
+impl<M: DeserializeOwned + std::fmt::Debug + Send + 'static> Receiver<M> {
+    /// Spawn a new network receiver handling connections from any incoming peer.
+    pub fn new(address: SocketAddr, sender: mpsc::Sender<M>) -> Self {
+        // FIXME create channel here
+        Self { address, sender }
+    }
+
+    /// Main loop responsible to accept incoming connections and spawn a new runner to handle it.
+    pub async fn run(&self) {
+        let listener = TcpListener::bind(&self.address)
+            .await
+            .expect("Failed to bind TCP port");
+
+        debug!("Listening on {}", self.address);
+        loop {
+            let (socket, peer) = match listener.accept().await {
+                Ok(value) => value,
+                Err(e) => {
+                    warn!("{}", NetworkError::FailedToListen(e));
+                    continue;
+                }
+            };
+            debug!("Incoming connection established with {}", peer);
+            Self::spawn_runner(socket, peer, self.sender.clone()).await;
+        }
+    }
+
+    /// Spawn a new runner to handle a specific TCP connection. It receives messages and process them
+    /// using the provided handler.
+    async fn spawn_runner(socket: TcpStream, peer: SocketAddr, sender: mpsc::Sender<M>) {
+        tokio::spawn(async move {
+            let transport = Framed::new(socket, LengthDelimitedCodec::new());
+            // FIXME add optional writing
+            let (mut _writer, mut reader) = transport.split();
+            while let Some(frame) = reader.next().await {
+                match frame.map_err(|e| NetworkError::FailedToReceiveMessage(peer, e)) {
+                    Ok(message) => {
+                        // FIXME unwrap
+                        let request = bincode::deserialize(&message.freeze()).unwrap();
+                        sender.send(request).await.unwrap();
+                    }
+                    Err(e) => {
+                        warn!("{}", e);
+                        return;
+                    }
+                }
+            }
+            debug!("Connection closed by peer {}", peer);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use futures::sink::SinkExt as _;
+    use tokio::sync::mpsc::channel;
+    use tokio::sync::mpsc::Sender;
+    use tokio::time::{sleep, Duration};
+
+    use async_trait::async_trait;
+    use tokio::net::TcpStream;
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    #[derive(Clone)]
+    struct TestHandler {
+        deliver: Sender<String>,
+    }
+
+    #[async_trait]
+    impl MessageHandler for TestHandler {
+        async fn dispatch(&mut self, writer: &mut Writer, message: Bytes) -> Result<()> {
+            // Reply with an ACK.
+            let _ = writer.send(Bytes::from("Ack")).await;
+
+            // Deserialize the message.
+            let message = bincode::deserialize(&message).unwrap();
+
+            // Deliver the message to the application.
+            self.deliver.send(message).await.unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn receive() {
+        // Make the network receiver.
+        let address = "127.0.0.1:4000".parse::<SocketAddr>().unwrap();
+        let (tx, mut rx) = channel(1);
+        tokio::spawn(async move {
+            let receiver = Receiver::new(address, TestHandler { deliver: tx });
+            receiver.run().await;
+        });
+        sleep(Duration::from_millis(50)).await;
+
+        // Send a message.
+        let sent = "Hello, world!";
+        let bytes = Bytes::from(bincode::serialize(sent).unwrap());
+        let stream = TcpStream::connect(address).await.unwrap();
+        let mut transport = Framed::new(stream, LengthDelimitedCodec::new());
+        transport.send(bytes.clone()).await.unwrap();
+
+        // Ensure the message gets passed to the channel.
+        let message = rx.recv().await;
+        assert!(message.is_some());
+        let received = message.unwrap();
+        assert_eq!(received, sent);
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,6 +7,8 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
+pub type CommandResult = Result<Option<String>, String>;
+
 #[derive(Debug, Serialize, Deserialize, Parser, Clone, PartialEq, Eq)]
 #[clap()]
 pub enum ClientCommand {
@@ -24,7 +26,7 @@ impl ClientCommand {
         let reply_handler = sender.send(address, message).await;
 
         let response = reply_handler.await?;
-        let response: Result<Option<String>, String> = bincode::deserialize(&response)?;
+        let response: CommandResult = bincode::deserialize(&response)?;
         response.map_err(|e| anyhow!(e))
     }
 }


### PR DESCRIPTION
This PR has two related changes:

* Applies the idea discussed before of having two separate TCP listeners for client and network (i.e. peer messages). This helps removing some deserialization hackery for deciding how to interpret incoming TCP messages, and in general seems more akin to a production implementation to separate client requests from internal consensus messages.
* Explores the idea of removing the MessageHandler trait and instead make the network code assume that all TCP Receivers will want to deserialize packates and forward them over through a mpsc channel (with an optional response). This makes the networking code slightly more complex and a lot more opinionated but reduces boilerplate and duplication on the consensus implementation side, which seems like a good trade-off.

Note that the networking changes were a done on a copy of the receiver module and only applied in the blocckchain implementation so as to not disturb the rest of the codebase yet.

(Also, there may be more room for boilerplate removal after this change is applied)