### PR TITLE
Remove shared state references and locks and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --verbose
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --verbose
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
             profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
+            toolchain: nightly
             profile: minimal
       - uses: Swatinem/rust-cache@v1
+      - run: apt install -y clang libclang1
       - run: cargo test --verbose
   clippy:
     runs-on: [self-hosted]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Consensus Workbench CI
 on: push
 jobs:
   tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, nomad]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -13,7 +13,7 @@ jobs:
       - run: apt install -y clang libclang1
       - run: cargo test --verbose
   clippy:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, nomad]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,7 +24,7 @@ jobs:
       - run: apt install -y clang libclang1
       - run: cargo +nightly clippy
   format:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, nomad]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/src/lock_commit/main.rs
+++ b/src/lock_commit/main.rs
@@ -248,6 +248,8 @@ mod tests {
         assert!(reply.is_some());
         assert_eq!("v1".to_string(), reply.unwrap());
 
+        sleep(Duration::from_millis(100)).await;
+
         // get value on replica to make sure it was replicated
         let reply = Command::Client(ClientCommand::Get {
             key: "k1".to_string(),

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -31,15 +31,15 @@ pub struct Node {
 
     // fixme: shared state is wrapped in Arc<RwLock<>>s because this is cloned for every received request
     // in the future, we want to implement a channel-based solution like in some of the other PoCs
-    pub current_view: Arc<RwLock<u128>>,
+    pub current_view: u128,
     pub timer_start: Arc<RwLock<Instant>>,
-    pub command_view_lock: Arc<RwLock<CommandView>>,
+    pub command_view_lock: CommandView,
 
     // the amount of peers which responded with "Lock"
     // note: if we were to create a QC to store in the blockchain,
     // we would need to store signatures from peers here
-    pub lock_responses: Arc<Mutex<HashSet<SocketAddr>>>,
-    pub blame_messages: Arc<Mutex<HashSet<SocketAddr>>>,
+    pub lock_responses: HashSet<SocketAddr>,
+    pub blame_messages: HashSet<SocketAddr>,
 }
 
 /// The state of a node viewed as a state-machine.
@@ -89,10 +89,10 @@ impl Node {
             store: Store::new(db_path).unwrap(),
             peers: peers,
             sender: SimpleSender::new(),
-            current_view: Arc::new(RwLock::new(0)),
-            command_view_lock: Arc::new(RwLock::new(CommandView::new())),
-            lock_responses: Arc::new(Mutex::new(HashSet::new())),
-            blame_messages: Arc::new(Mutex::new(HashSet::new())),
+            current_view: 0,
+            command_view_lock: CommandView::new(),
+            lock_responses: HashSet::new(),
+            blame_messages: HashSet::new(),
             socket_address: address,
             timer_start,
         }
@@ -128,7 +128,7 @@ impl Node {
                 // we advance the view according to the primary and propose it
                 let command_view = CommandView {
                     command: client_comand,
-                    view: *self.current_view.read().unwrap() + 1,
+                    view: self.current_view + 1,
                 };
 
                 // since we are primary, we lock the command view
@@ -214,7 +214,7 @@ impl Node {
                     highest_lock: _,
                 }),
             ) => {
-                if new_view > *self.current_view.read().unwrap() {
+                if new_view > self.current_view {
                     info!(
                         "{}: View-change performed, primary is {}",
                         self.socket_address,
@@ -249,12 +249,12 @@ impl Node {
         socket_addr: SocketAddr,
         command_view: CommandView,
     ) -> Result<Option<Vec<u8>>, anyhow::Error> {
-        if command_view.view <= *self.current_view.read().unwrap() {
+        if command_view.view <= self.current_view {
             info!("Received command with an old, previously committed view, discarding");
             Ok(None)
         } else {
-            let _ = self.lock_responses.lock().unwrap().insert(socket_addr);
-            let response_count = self.lock_responses.lock().unwrap().len();
+            let _ = self.lock_responses.insert(socket_addr);
+            let response_count = self.lock_responses.len();
 
             // the literature defines quorum as a function of the adversarial threshold we want to support
             // n > f, n > 2f, or n > 3f are the alternatives; this uses n > 2f model
@@ -318,7 +318,7 @@ impl Node {
 
     async fn send_to_primary(&mut self, cmd: Command) {
         let message: Bytes = bincode::serialize(&cmd).unwrap().into();
-        let primary_address = *(self.get_primary(*self.current_view.read().unwrap()));
+        let primary_address = *(self.get_primary(self.current_view));
 
         // forward the command to all replicas and wait for them to respond
         let _ = self.sender.send(primary_address, message).await;
@@ -328,12 +328,12 @@ impl Node {
         *self.timer_start.write().unwrap() = Instant::now();
 
         // handle command, remove command lock (Primray already commits when quorum is achieved)
-        if *self.command_view_lock.read().unwrap() != command_view {
+        if self.command_view_lock != command_view {
             info!(
                 "{}: trying to commit {:?} but we had locked {:?}",
                 self.socket_address,
                 command_view,
-                *self.command_view_lock.read().unwrap()
+                self.command_view_lock
             );
             // we are trying to commit something that has not been locked correctly,
             // so there must have been some fault
@@ -342,14 +342,11 @@ impl Node {
             ));
         }
 
-        {
-            let mut lock = self.current_view.write().unwrap(); // update last valid view number
-            *lock = command_view.view;
-        }
+        self.current_view = command_view.view;
+        self.command_view_lock.view += 1;
 
-        self.command_view_lock.write().unwrap().view += 1;
         // handle command
-        self.lock_responses.lock().unwrap().clear();
+        self.lock_responses.clear();
         self.clear_cmd_view_lock();
 
         self.handle_client_command(command_view.command).await
@@ -357,30 +354,28 @@ impl Node {
 
     fn lock_command_view(&mut self, command_view: &CommandView) {
         if command_view.view != 0 {
-            let mut lock = self.command_view_lock.write().unwrap();
-            *lock = command_view.clone();
+            self.command_view_lock = command_view.clone();
         }
         info!(
             "{}: Locked command view {:?}",
             self.socket_address,
-            *self.command_view_lock.read().unwrap()
+            self.command_view_lock
         );
     }
 
     pub fn get_state(&self) -> State {
-        if self.get_primary(*self.current_view.read().unwrap()) == &self.socket_address {
+        if self.get_primary(self.current_view) == &self.socket_address {
             return State::Primary;
         }
         State::Backup
     }
 
     fn trigger_view_change(&mut self, new_view: u128) {
-        let mut lock = self.current_view.write().unwrap(); // update last valid view number
-        *lock = new_view;
+        self.current_view = new_view; // update last valid view number
 
-        self.lock_responses.lock().unwrap().clear();
-        self.blame_messages.lock().unwrap().clear();
-        *self.command_view_lock.write().unwrap() = CommandView::new();
+        self.lock_responses.clear();
+        self.blame_messages.clear();
+        self.command_view_lock = CommandView::new();
     }
 
     fn get_primary(&self, view: u128) -> &SocketAddr {
@@ -388,7 +383,7 @@ impl Node {
     }
 
     fn clear_cmd_view_lock(&mut self) {
-        *self.command_view_lock.write().unwrap() = CommandView::new();
+        self.command_view_lock = CommandView::new();
     }
 
     async fn handle_blame(
@@ -397,14 +392,14 @@ impl Node {
         socket_addr: SocketAddr,
         timer_expired: bool,
     ) -> Result<Option<Vec<u8>>> {
-        if view != *self.current_view.read().unwrap() && !timer_expired {
+        if view != self.current_view && !timer_expired {
             return Ok(None);
         }
 
-        let _ = self.blame_messages.lock().unwrap().insert(socket_addr);
-        let blame_count = self.blame_messages.lock().unwrap().len();
+        let _ = self.blame_messages.insert(socket_addr);
+        let blame_count = self.blame_messages.len();
 
-        let highest_view_lock = (self.command_view_lock.read().unwrap()).clone();
+        let highest_view_lock = self.command_view_lock.clone();
 
         // from the docs, f is the amount of omission failures we want to tolerate
         // again, f is defined from the adversarial threshold of the system
@@ -415,7 +410,7 @@ impl Node {
             "Received blame, did we get quorum? {} responses so far vs expected quorum of {} ",
             blame_count, quorum_count
         );
-        let current_view = *self.current_view.read().unwrap();
+        let current_view = self.current_view;
 
         // if we receive enough blames, even if the timer did not go off yet,
         // we send out the blame message

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -331,9 +331,7 @@ impl Node {
         if self.command_view_lock != command_view {
             info!(
                 "{}: trying to commit {:?} but we had locked {:?}",
-                self.socket_address,
-                command_view,
-                self.command_view_lock
+                self.socket_address, command_view, self.command_view_lock
             );
             // we are trying to commit something that has not been locked correctly,
             // so there must have been some fault
@@ -358,8 +356,7 @@ impl Node {
         }
         info!(
             "{}: Locked command view {:?}",
-            self.socket_address,
-            self.command_view_lock
+            self.socket_address, self.command_view_lock
         );
     }
 


### PR DESCRIPTION
As a consequence of the changes to use channels to process incoming messages, there is no more necessity to share state between cloned Node objects, so this PR removes all shared state.

This PR also adds a couple of dependencies in the CI in order to get `cargo test` working correctly.