### PR TITLE
Timer, tests and general cleanup for lock-commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,5 @@ use anyhow::Result;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
-pub type NetworkReciver<T> = mpsc::Receiver<(T, oneshot::Sender<Result<Option<Vec<u8>>>>)>;
+pub type NetworkReceiver<T> = mpsc::Receiver<(T, oneshot::Sender<Result<Option<Vec<u8>>>>)>;
 pub type NetworkSender<T> = mpsc::Sender<(T, oneshot::Sender<Result<Option<Vec<u8>>>>)>;

--- a/src/lock_commit/command_ext.rs
+++ b/src/lock_commit/command_ext.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, Result};
 pub enum Command {
     Client(ClientCommand),
     Network(NetworkCommand),
+    Test
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/lock_commit/command_ext.rs
+++ b/src/lock_commit/command_ext.rs
@@ -12,7 +12,6 @@ use anyhow::{anyhow, Result};
 pub enum Command {
     Client(ClientCommand),
     Network(NetworkCommand),
-    Test,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/lock_commit/command_ext.rs
+++ b/src/lock_commit/command_ext.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 pub enum Command {
     Client(ClientCommand),
     Network(NetworkCommand),
-    Test
+    Test,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/lock_commit/command_ext.rs
+++ b/src/lock_commit/command_ext.rs
@@ -54,7 +54,7 @@ impl Command {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct CommandView {
     pub command: ClientCommand, // lock_value
     pub view: u128,             // lock_view

--- a/src/lock_commit/main.rs
+++ b/src/lock_commit/main.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_only_primary_server() {
-        let address: SocketAddr = "127.0.0.1:6379".parse().unwrap();
+        let address: SocketAddr = "127.0.0.1:9900".parse().unwrap();
         fs::remove_dir_all(".db_test_primary1").unwrap_or_default();
         let node = node::Node::new(vec![address], &db_path("primary1"), address, None);
 
@@ -165,8 +165,8 @@ mod tests {
         fs::remove_dir_all(".db_test_primary2").unwrap_or_default();
         fs::remove_dir_all(".db_test_backup2").unwrap_or_default();
 
-        let address_primary: SocketAddr = "127.0.0.1:6380".parse().unwrap();
-        let address_replica: SocketAddr = "127.0.0.1:6381".parse().unwrap();
+        let address_primary: SocketAddr = "127.0.0.1:7665".parse().unwrap();
+        let address_replica: SocketAddr = "127.0.0.1:7667".parse().unwrap();
 
         let backup = node::Node::new(
             vec![address_primary, address_replica],
@@ -232,8 +232,8 @@ mod tests {
 
     #[tokio::test()]
     async fn test_view_change() {
-        let address_primary: SocketAddr = "127.0.0.1:6280".parse().unwrap();
-        let address_replica: SocketAddr = "127.0.0.1:6281".parse().unwrap();
+        let address_primary: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        let address_replica: SocketAddr = "127.0.0.1:9998".parse().unwrap();
 
         let backup = Box::new(node::Node::new(
             vec![address_primary, address_replica],

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -119,6 +119,7 @@ impl Node {
                 timer_expired: false,
             })
             .await;
+
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
@@ -220,11 +221,7 @@ impl Node {
 
             // the backup gets a Commit message after we reach quorum, so we can go ahead and commit
             (Backup, Command::Network(NetworkCommand::Commit { command_view })) => {
-<<<<<<< HEAD
                 match self.try_commit(command_view).await {
-=======
-                let result = match self.try_commit(command_view).await {
->>>>>>> 3901c4d (handle timer)
                     Ok(result) => {
                         info!(
                             "{}: Committed command, response was {:?}",

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -119,7 +119,6 @@ impl Node {
                 timer_expired: false,
             })
             .await;
-
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -83,7 +83,7 @@ impl Node {
         peers: Vec<SocketAddr>,
         db_path: &str,
         address: SocketAddr,
-        view_change_delta_ms: Option<u16>, 
+        view_change_delta_ms: Option<u16>,
     ) -> Self {
         Self {
             store: Store::new(db_path).unwrap(),

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -13,6 +13,7 @@ use lib::{
     NetworkReceiver, NetworkSender,
 };
 use log::info;
+use serde::Serialize;
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -152,7 +153,6 @@ impl Node {
             (_, Command::Client(cmd @ ClientCommand::Get { key: _ })) => {
                 self.handle_client_command(cmd).await
             }
-
             // if we receive a client command that is not a get and we are primary, prepare to propose
             (Primary, Command::Client(client_comand)) => {
                 // we advance the view according to the primary and propose it

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -220,7 +220,11 @@ impl Node {
 
             // the backup gets a Commit message after we reach quorum, so we can go ahead and commit
             (Backup, Command::Network(NetworkCommand::Commit { command_view })) => {
+<<<<<<< HEAD
                 match self.try_commit(command_view).await {
+=======
+                let result = match self.try_commit(command_view).await {
+>>>>>>> 3901c4d (handle timer)
                     Ok(result) => {
                         info!(
                             "{}: Committed command, response was {:?}",

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -13,7 +13,7 @@ use lib::{
     NetworkReceiver, NetworkSender,
 };
 use log::info;
-use serde::Serialize;
+
 use std::{
     collections::HashSet,
     net::SocketAddr,

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -5,7 +5,7 @@ use crate::command_ext::{Command, CommandView, NetworkCommand};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{sink::SinkExt as _};
+use futures::sink::SinkExt as _;
 use lib::{
     command::ClientCommand,
     network::{MessageHandler, SimpleSender, Writer},
@@ -220,7 +220,6 @@ impl Node {
 
             // the backup gets a Commit message after we reach quorum, so we can go ahead and commit
             (Backup, Command::Network(NetworkCommand::Commit { command_view })) => {
-                
                 match self.try_commit(command_view).await {
                     Ok(result) => {
                         info!(

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -32,10 +32,7 @@ pub struct Node {
     pub view_change_delta_ms: Option<u16>,
     pub timer_start: time::Instant,
 
-    // fixme: shared state is wrapped in Arc<RwLock<>>s because this is cloned for every received request
-    // in the future, we want to implement a channel-based solution like in some of the other PoCs
     pub current_view: u128,
-    //pub timer_start: Arc<RwLock<Instant>>,
     pub command_view_lock: CommandView,
 
     // the amount of peers which responded with "Lock"
@@ -86,7 +83,7 @@ impl Node {
         peers: Vec<SocketAddr>,
         db_path: &str,
         address: SocketAddr,
-        view_change_delta_ms: Option<u16>, //   timer_start: Arc<RwLock<Instant>>,
+        view_change_delta_ms: Option<u16>, 
     ) -> Self {
         Self {
             store: Store::new(db_path).unwrap(),

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -13,11 +13,9 @@ use lib::{
     NetworkReceiver, NetworkSender,
 };
 use log::info;
-use serde::de::IntoDeserializer;
 use std::{
     collections::HashSet,
     net::SocketAddr,
-    sync::{Arc, RwLock},
     time::{self, Duration, Instant},
 };
 use tokio::sync::oneshot;

--- a/src/lock_commit/node.rs
+++ b/src/lock_commit/node.rs
@@ -5,7 +5,7 @@ use crate::command_ext::{Command, CommandView, NetworkCommand};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{future::join, sink::SinkExt as _};
+use futures::{sink::SinkExt as _};
 use lib::{
     command::ClientCommand,
     network::{MessageHandler, SimpleSender, Writer},
@@ -220,7 +220,8 @@ impl Node {
 
             // the backup gets a Commit message after we reach quorum, so we can go ahead and commit
             (Backup, Command::Network(NetworkCommand::Commit { command_view })) => {
-                let result = match self.try_commit(command_view).await {
+                
+                match self.try_commit(command_view).await {
                     Ok(result) => {
                         info!(
                             "{}: Committed command, response was {:?}",
@@ -230,8 +231,7 @@ impl Node {
                         Ok(None)
                     }
                     _ => Err(anyhow!("Error committing command")),
-                };
-                result
+                }
             }
             // View change moves the view/primary after enough blames were emitted
             (

--- a/src/lock_commit/start.sh
+++ b/src/lock_commit/start.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Start a number of nodes running on different sockets. The amount of nodes that start should be passed to the script as its only argument.
-# Example call: ./start.sh 3
+# Start a number of nodes running on different sockets. The amount of nodes that start should be passed to the script as its first argument, and the second should be the delta for the timer in miliseconds.
+# Example call: ./start.sh 3 100
 
-if [ $# -ne 1 ]
+if [ $# -ne 1 ] && [ $# -ne 2 ]
 then
-  echo "Incorrect number of arguments. Usage: ./start.sh {number-of-nodes}"
+  echo "Incorrect number of arguments. Usage: ./start.sh {number-of-nodes} {timer-delta-ms}" 
   exit 1
 fi
 
@@ -20,7 +20,7 @@ done
 
 while [ $j -lt $1 ]; do
    PORT=$((6100+$j))
-   RUST_LOG=INFO ../../target/debug/node_lock_commit --port $PORT --peers "$LIST_PEERS" &
+   RUST_LOG=INFO ../../target/debug/node_lock_commit --port $PORT --peers "$LIST_PEERS" -v $2 &
    
    j=$((j + 1))
 done

--- a/src/primary_backup/node.rs
+++ b/src/primary_backup/node.rs
@@ -9,7 +9,7 @@ use lib::command::ClientCommand;
 use lib::{
     network::{MessageHandler, ReliableSender, Writer},
     store::Store,
-    NetworkReciver, NetworkSender,
+    NetworkReceiver, NetworkSender,
 };
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -126,7 +126,7 @@ impl Node {
     }
 
     /// Runs the node to process network messages incoming in the given receiver
-    pub async fn run(&mut self, mut network_receiver: NetworkReciver<Message>) {
+    pub async fn run(&mut self, mut network_receiver: NetworkReceiver<Message>) {
         while let Some((message, reply_sender)) = network_receiver.recv().await {
             self.handle_msg(message, reply_sender).await;
         }

--- a/src/single_node/node.rs
+++ b/src/single_node/node.rs
@@ -8,7 +8,7 @@ use lib::{
     command::ClientCommand,
     network::{MessageHandler, Writer},
     store::Store,
-    NetworkReciver, NetworkSender,
+    NetworkReceiver, NetworkSender,
 };
 use tokio::sync::oneshot;
 
@@ -26,7 +26,7 @@ impl Node {
     }
 
     /// Runs the node to process network messages incoming in the given receiver
-    pub async fn run(&mut self, mut network_receiver: NetworkReciver<ClientCommand>) {
+    pub async fn run(&mut self, mut network_receiver: NetworkReceiver<ClientCommand>) {
         while let Some((message, reply_sender)) = network_receiver.recv().await {
             self.handle_msg(message, reply_sender).await;
         }


### PR DESCRIPTION
- Timer implementation for view-change is now a little bit cleaner and does not run on its own thread
- A test was added for view-change. I could not find an easier way of reading the final values of the node struct, because it gets consumed by the function that starts the pertinent tasks
- General fixes/cleanups